### PR TITLE
Add a config file which defines aliases for server URLs

### DIFF
--- a/docs/source/aliases.rst
+++ b/docs/source/aliases.rst
@@ -1,0 +1,34 @@
+Server aliases
+==============
+
+In order to avoid the need to enter a long server URL every time a
+connection is opened, the module provides a yaml configuration file
+which can be used to define an `alias`, or short name, for the
+server. On linux this file is stored in::
+
+    ~/.config/hdfstream/config.yml
+
+The default configuration looks like this::
+
+    aliases:
+      cosma:
+        url: https://dataweb.cosma.dur.ac.uk:8443/hdfstream
+        use_keyring: false
+        user: null
+
+This defines an alias called ``cosma`` for the URL
+``https://dataweb.cosma.dur.ac.uk:8443/hdfstream``.
+
+Authentication
+--------------
+
+The server might require authentication for access to certain
+datasets. The ``user`` field in the config file can be used to specify
+a default username to use when making requests to the corresponding
+server.
+
+If the ``use_keyring`` field is ``true`` and a username is set, then
+the module will try to use the system keyring (via the `python keyring
+module <https://pypi.org/project/keyring/>`__) to fetch the
+password. If the password is not in the keyring then the module
+prompts for a password and stores it in the keyring if it works.

--- a/docs/source/aliases.rst
+++ b/docs/source/aliases.rst
@@ -3,8 +3,8 @@ Server aliases
 
 In order to avoid the need to enter a long server URL every time a
 connection is opened, the module provides a yaml configuration file
-which can be used to define an `alias`, or short name, for the
-server. On linux this file is stored in::
+which can be used to define aliases, or short names, for servers.
+On linux this file is stored in::
 
     ~/.config/hdfstream/config.yml
 
@@ -32,3 +32,15 @@ the module will try to use the system keyring (via the `python keyring
 module <https://pypi.org/project/keyring/>`__) to fetch the
 password. If the password is not in the keyring then the module
 prompts for a password and stores it in the keyring if it works.
+
+Writing a new default configuration file
+----------------------------------------
+
+To create a new configuration and save it as the default::
+
+    config = hdfstream.Config()
+    config.add_alias("test_alias", "test_url", user="test_user", use_keyring=True)
+    config.write(mode="w") # Overwrites the default config file
+    hdfstream.set_config(config) # Sets the configuration for this session
+
+The default configuration can be restored by deleting the config.yml file.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,3 +36,6 @@ exclude_patterns = []
 
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
+
+# API documentation ordering
+autodoc_member_order = 'bysource'

--- a/docs/source/connecting.rst
+++ b/docs/source/connecting.rst
@@ -9,6 +9,6 @@ using the :py:func:`hdfstream.open` function::
   import hdfstream
   root = hdfstream.open("https://localhost:8443/hdfstream", "/")
 
-Here, the first parameter is the server URL and the second is the
-virtual directory on the server which we'd like to access. This
+Here, the first parameter is the server URL or :doc:`alias </aliases>` and the second is
+the virtual directory on the server which we'd like to access. This
 command returns a :py:class:`hdfstream.RemoteDirectory` object.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ See the links below for usage information and the API reference.
    groups
    datasets
    multi_slice
+   aliases
    lazy_loading
    testing
    api

--- a/hdfstream/__init__.py
+++ b/hdfstream/__init__.py
@@ -2,7 +2,7 @@
 
 __all__ = ["verify_cert", "disable_progress", "set_progress_delay", "open",
            "RemoteDirectory", "RemoteFile", "RemoteGroup", "RemoteDataset",
-           "SoftLink", "HardLink", "testing"]
+           "SoftLink", "HardLink", "testing", "get_config", "Config"]
 
 
 from importlib.metadata import version, PackageNotFoundError
@@ -21,6 +21,7 @@ from hdfstream.remote_group import RemoteGroup
 from hdfstream.remote_dataset import RemoteDataset
 from hdfstream.remote_links import SoftLink, HardLink
 from hdfstream.defaults import *
+from hdfstream.config import get_config, Config
 
 
 def open(server, name, user=None, password=None, max_depth=max_depth_default,

--- a/hdfstream/__init__.py
+++ b/hdfstream/__init__.py
@@ -2,7 +2,8 @@
 
 __all__ = ["verify_cert", "disable_progress", "set_progress_delay", "open",
            "RemoteDirectory", "RemoteFile", "RemoteGroup", "RemoteDataset",
-           "SoftLink", "HardLink", "testing", "get_config", "Config"]
+           "SoftLink", "HardLink", "testing", "Config", "get_config",
+           "set_config"]
 
 
 from importlib.metadata import version, PackageNotFoundError
@@ -21,7 +22,7 @@ from hdfstream.remote_group import RemoteGroup
 from hdfstream.remote_dataset import RemoteDataset
 from hdfstream.remote_links import SoftLink, HardLink
 from hdfstream.defaults import *
-from hdfstream.config import get_config, Config
+from hdfstream.config import get_config, set_config, Config
 
 
 def open(server, name, user=None, password=None, max_depth=max_depth_default,

--- a/hdfstream/__init__.py
+++ b/hdfstream/__init__.py
@@ -21,7 +21,6 @@ from hdfstream.remote_group import RemoteGroup
 from hdfstream.remote_dataset import RemoteDataset
 from hdfstream.remote_links import SoftLink, HardLink
 from hdfstream.defaults import *
-from hdfstream.config import Config
 
 
 def open(server, name, user=None, password=None, max_depth=max_depth_default,

--- a/hdfstream/__init__.py
+++ b/hdfstream/__init__.py
@@ -1,9 +1,9 @@
 #!/bin/env python
 
-__all__ = ["verify_cert", "disable_progress", "set_progress_delay", "open",
-           "RemoteDirectory", "RemoteFile", "RemoteGroup", "RemoteDataset",
-           "SoftLink", "HardLink", "testing", "Config", "get_config",
-           "set_config"]
+__all__ = ["open", "RemoteDirectory", "RemoteFile", "RemoteGroup",
+           "RemoteDataset", "SoftLink", "HardLink", "disable_progress",
+           "set_progress_delay", "Config", "get_config", "set_config",
+           "verify_cert", "testing"]
 
 
 from importlib.metadata import version, PackageNotFoundError

--- a/hdfstream/__init__.py
+++ b/hdfstream/__init__.py
@@ -21,6 +21,8 @@ from hdfstream.remote_group import RemoteGroup
 from hdfstream.remote_dataset import RemoteDataset
 from hdfstream.remote_links import SoftLink, HardLink
 from hdfstream.defaults import *
+from hdfstream.config import Config
+
 
 def open(server, name, user=None, password=None, max_depth=max_depth_default,
          data_size_limit=data_size_limit_default):

--- a/hdfstream/config.py
+++ b/hdfstream/config.py
@@ -21,25 +21,64 @@ class Config:
     Class to store module configuration info
     """
     def __init__(self):
-
-        config_path = platformdirs.user_config_path(appname="hdfstream", ensure_exists=True)
-        config_path = config_path / "config.yml"
-
-        # Write the default config file if necessary
-        try:
-            with open(config_path, "x") as config_file:
-                yaml.dump(default_config, config_file)
-        except FileExistsError:
-            pass
-
-        # Read the current config
-        with open(config_path, "r") as config_file:
-            self._config = yaml.safe_load(config_file)
-
-        # Set up dict of aliases
+        """
+        Create a new, empty configuration object
+        """
+        self._config_path = platformdirs.user_config_path(appname="hdfstream", ensure_exists=True)
+        self._config_path = self._config_path / "config.yml"
         self._alias = {}
-        for name in self._config["aliases"].keys():
-            self._alias[name] = self._config["aliases"][name]
+
+    def add_alias(self, name, url, user=None, use_keyring=False):
+        """
+        Add a new alias for the specified URL
+        """
+        self._alias[name] = {
+            "url" : url,
+            "user" : user,
+            "use_keyring" : use_keyring,
+        }
+
+    def write(self, filename=None, mode="x"):
+        """
+        Write this config object to a yaml file
+        """
+        if filename is None:
+            filename = self._config_path
+        config = {"aliases" : self._alias}
+        with open(filename, mode) as config_file:
+            yaml.dump(config, config_file)
+
+    def read(self, filename=None):
+        """
+        Read and validate the specified config file
+        """
+        if filename is None:
+            filename = self._config_path
+        with open(filename, "r") as config_file:
+            config = yaml.safe_load(config_file)
+
+        # Should be a dict with an "aliases" key
+        if not isinstance(config, dict) or "aliases" not in config.keys():
+            raise TypeError("Config should contain a dict of aliases")
+
+        # Validate aliases in the config file
+        for key, val in config["aliases"].items():
+            if not isinstance(key, str):
+                raise TypeError("Alias names must be strings")
+            url = val["url"]
+            if not isinstance(url, str):
+                raise TypeError("Alias URLs must be strings")
+            user = val.get("user", None)
+            if user is not None and not isinstance(user, str):
+                raise TypeError("Alias user names must be strings")
+            use_keyring = val.get("use_keyring", False)
+            if not isinstance(use_keyring, bool):
+                raise TypeError("Alias use_keyring flag must be bool")
+            self._alias[key] = {
+                "url" : url,
+                "user" : user,
+                "use_keyring" : use_keyring,
+            }
 
     def resolve_alias(self, name, user):
         """
@@ -66,5 +105,37 @@ class Config:
 
         return name, user, use_keyring
 
-# Read (or create) the config file with server aliases
-config = Config()
+
+def _default_config():
+    """
+    Return a default configuration object
+    """
+    config = Config()
+    config.add_alias("cosma", "https://dataweb.cosma.dur.ac.uk:8443/hdfstream")
+    return config
+
+
+def _read_user_config():
+    """
+    Try to read the user's default config file
+    """
+    config = Config()
+    config.read()
+    return config
+
+
+_config = None
+def get_config():
+    """
+    Return a Config object
+
+    Reads the user's config file if possible. Writes a new default config
+    otherwise.
+    """
+    global _config
+    try:
+        _config = _read_user_config()
+    except OSError:
+        _config = _default_config()
+        _config.write()
+    return _config

--- a/hdfstream/config.py
+++ b/hdfstream/config.py
@@ -31,6 +31,15 @@ class Config:
     def add_alias(self, name, url, user=None, use_keyring=False):
         """
         Add a new alias for the specified URL
+
+        :param name: name of the alias to create
+        :type name: str
+        :param url: URL of the alias to create
+        :type url: str
+        :param user: default username to use when connecting
+        :type user: str or None
+        :param use_keyring: whether to use the system keyring to store passwords
+        :type use_keyring: bool
         """
         self._alias[name] = {
             "url" : url,
@@ -40,7 +49,14 @@ class Config:
 
     def write(self, filename=None, mode="x"):
         """
-        Write this config object to a yaml file
+        Write this config object to a yaml file. Writes to config.yml in
+        the user's default configuration directory (supplied by the
+        platformdirs module) if no filename is provided.
+
+        :param filename: name of the file to write
+        :type filename: str or None
+        :param mode: mode used to open the file (usually 'w' or 'x')
+        :type mode: str
         """
         if filename is None:
             filename = self._config_path
@@ -50,7 +66,12 @@ class Config:
 
     def read(self, filename=None):
         """
-        Read and validate the specified config file
+        Read the specified config file and update this Config object.
+        Reads config.yml in the user's default configuration directory
+        (supplied by the platformdirs module) if no filename is provided.
+
+        :param filename: name of the file to write
+        :type filename: str or None
         """
         if filename is None:
             filename = self._config_path
@@ -82,16 +103,19 @@ class Config:
 
     def resolve_alias(self, name, user):
         """
-        Given an alias, return the corresponding server URL and
-        the user name to use. If no match is found, assume the name is
-        already a URL and return it.
+        Given an alias, return the corresponding server URL, the user name
+        to use, and a flag indicating if we should use the system keyring
+        to access passwords. If the supplied name is not an alias then it
+        is assumed to be a URL already and is returned unmodified. If a
+        username is specified, it overrides any configured username.
 
-        If a username is specified, it overrides the stored username.
+        :param name: name of the alias to look up
+        :type name: str
+        :param user: overrides configured user name if not None
+        :type user: str or None
 
-        Also returns use_keyring, which specifies if we should try to
-        access the system keyring.
+        :rtype: (str, str, bool)
         """
-
         use_keyring = False
         alias = self._alias.get(name, None)
         if alias is not None:
@@ -127,10 +151,10 @@ def _read_user_config():
 _config = None
 def get_config():
     """
-    Return a Config object
+    Return the active configuration object. Read the user's config file if
+    possible, otherwise write a new default config file.
 
-    Reads the user's config file if possible. Writes a new default config
-    otherwise.
+    :rtype: hdfstream.Config
     """
     global _config
     try:

--- a/hdfstream/config.py
+++ b/hdfstream/config.py
@@ -1,0 +1,51 @@
+#!/bin/env python
+
+import yaml
+import platformdirs
+
+#
+# Contents of the default configuration file
+#
+default_config = {
+    "aliases" : {
+        "cosma" : {"url" : "https://dataweb.cosma.dur.ac.uk:8443/hdfstream",}
+    },
+}
+
+class Config:
+    """
+    Class to store module configuration info
+    """
+    def __init__(self):
+
+        config_path = platformdirs.user_config_path(appname="hdfstream", ensure_exists=True)
+        config_path = config_path / "config.yml"
+
+        # Write the default config file if necessary
+        try:
+            with open(config_path, "x") as config_file:
+                yaml.dump(default_config, config_file)
+        except FileExistsError:
+            pass
+
+        # Read the current config
+        with open(config_path, "r") as config_file:
+            self._config = yaml.safe_load(config_file)
+
+        # Set up dict of aliases
+        self._alias = {}
+        for name in self._config["aliases"].keys():
+            self._alias[name] = str(self._config["aliases"][name]["url"])
+
+    def get_url(self, name):
+        """
+        Given an alias, return the corresponding server URL. If no match is
+        found, assume the name is already a URL and return it.
+        """
+        if name in self._alias:
+            return self._alias[name]
+        else:
+            return name
+
+# Read (or create) the config file with server aliases
+config = Config()

--- a/hdfstream/config.py
+++ b/hdfstream/config.py
@@ -2,13 +2,18 @@
 
 import yaml
 import platformdirs
+import keyring
 
 #
 # Contents of the default configuration file
 #
 default_config = {
     "aliases" : {
-        "cosma" : {"url" : "https://dataweb.cosma.dur.ac.uk:8443/hdfstream",}
+        "cosma" : {
+            "url" : "https://dataweb.cosma.dur.ac.uk:8443/hdfstream",
+            "user" : None, # username in case authentication is required
+            "use_keyring" : False, # fetch password from system keyring if True
+            },
     },
 }
 
@@ -37,15 +42,35 @@ class Config:
         for name in self._config["aliases"].keys():
             self._alias[name] = str(self._config["aliases"][name]["url"])
 
-    def get_url(self, name):
+    def resolve_alias(self, name, user, password):
         """
         Given an alias, return the corresponding server URL. If no match is
         found, assume the name is already a URL and return it.
+
+        Also looks up any username and password we should use. If a username
+        is set and use_keyring is True, we will use a password from the keyring
+        or prompt for the password and store it.
+
+        If a username and password are provided we return those in preference
+        to the values from the config file and keyring.
         """
-        if name in self._alias:
-            return self._alias[name]
-        else:
-            return name
+
+        alias = self._alias.get(name, None)
+        if alias is not None:
+            # The specified server name is an alias
+            name = alias["url"]
+            # Get the username, if it wasn't specified
+            if user is None:
+                user = alias.get("user", None)
+            # Get the password, if it wasn't specified and we're using the keyring
+            use_keyring = alias.get("use_keyring", False)
+            if use_keyring and user is not None and password is None:
+                password = keyring.get_password(name, user)
+                if password is None:
+                    password = getpass.getpass(f"Enter password for {user} at {name} (will store in system keyring): ")
+                    # TODO: only store passwords that work!
+                    keyring.set_password(name, user, password)
+        return name, user, password
 
 # Read (or create) the config file with server aliases
 config = Config()

--- a/hdfstream/config.py
+++ b/hdfstream/config.py
@@ -3,6 +3,7 @@
 import yaml
 import platformdirs
 import keyring
+import getpass
 
 #
 # Contents of the default configuration file
@@ -40,7 +41,7 @@ class Config:
         # Set up dict of aliases
         self._alias = {}
         for name in self._config["aliases"].keys():
-            self._alias[name] = str(self._config["aliases"][name]["url"])
+            self._alias[name] = self._config["aliases"][name]
 
     def resolve_alias(self, name, user, password):
         """

--- a/hdfstream/config.py
+++ b/hdfstream/config.py
@@ -163,3 +163,12 @@ def get_config():
         _config = _default_config()
         _config.write()
     return _config
+
+
+def set_config(config):
+    """
+    Set the active configuration object
+
+    :param config: the Config object to use
+    :type config: hdfstream.Config
+    """

--- a/hdfstream/config.py
+++ b/hdfstream/config.py
@@ -172,3 +172,5 @@ def set_config(config):
     :param config: the Config object to use
     :type config: hdfstream.Config
     """
+    global _config
+    _config = config

--- a/hdfstream/connection.py
+++ b/hdfstream/connection.py
@@ -98,7 +98,7 @@ class Connection:
     def new(server, user, password=None):
 
         # Check if server name is an alias
-        server = config.get_url(server)
+        server, user, password = config.resolve_alias(server, user, password)
 
         # Remove any trailing slashes from the server name
         server = server.rstrip("/")

--- a/hdfstream/connection.py
+++ b/hdfstream/connection.py
@@ -77,9 +77,6 @@ class Connection:
 
     def __init__(self, server, user=None, password=None):
 
-        # Check if server name is an alias
-        server = config.get_url(server)
-
         # Remove any trailing slashes from the server name
         self.server = server.rstrip("/")
 

--- a/hdfstream/connection.py
+++ b/hdfstream/connection.py
@@ -15,6 +15,7 @@ from requests.auth import HTTPBasicAuth
 
 from hdfstream.exceptions import HDFStreamRequestError
 from hdfstream.decoding import decode_response
+from hdfstream.config import config
 
 
 _verify_cert = True
@@ -76,6 +77,9 @@ class Connection:
 
     def __init__(self, server, user=None, password=None):
 
+        # Check if server name is an alias
+        server = config.get_url(server)
+
         # Remove any trailing slashes from the server name
         self.server = server.rstrip("/")
 
@@ -95,6 +99,9 @@ class Connection:
 
     @staticmethod
     def new(server, user, password=None):
+
+        # Check if server name is an alias
+        server = config.get_url(server)
 
         # Remove any trailing slashes from the server name
         server = server.rstrip("/")

--- a/hdfstream/connection.py
+++ b/hdfstream/connection.py
@@ -16,7 +16,7 @@ from requests.auth import HTTPBasicAuth
 
 from hdfstream.exceptions import HDFStreamRequestError
 from hdfstream.decoding import decode_response
-from hdfstream.config import config
+from hdfstream.config import get_config
 
 
 _verify_cert = True
@@ -112,7 +112,7 @@ class Connection:
     def new(server, user, password=None):
 
         # Check if server name is an alias
-        server, user, use_keyring = config.resolve_alias(server, user)
+        server, user, use_keyring = get_config().resolve_alias(server, user)
 
         # Remove any trailing slashes from the server name
         server = server.rstrip("/")

--- a/hdfstream/testing.py
+++ b/hdfstream/testing.py
@@ -107,6 +107,10 @@ def pytest_recording_configure(config, vcr):
 def vcr_config():
     """
     Configure vcrpy to use the gzipped messagepack serializer. Should be
-    imported in conftest.py when using pytest.
+    imported in conftest.py when using pytest. Also strip out auth headers
+    in case we accidentally record an authenticated request.
     """
-    return {"serializer": "msgpack.gz"}
+    return {
+        "serializer": "msgpack.gz",
+        "filter_headers": [("authorization", "DUMMY")],
+    }

--- a/hdfstream/testing.py
+++ b/hdfstream/testing.py
@@ -114,3 +114,6 @@ def vcr_config():
         "serializer": "msgpack.gz",
         "filter_headers": [("authorization", "DUMMY")],
     }
+
+class KeyringNotAvailableError(Exception):
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "pytest",
     "pytest-recording",
     "h5py",
+    "platformdirs",
+    "pyyaml",
 ]
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "h5py",
     "platformdirs",
     "pyyaml",
+    "keyring",
 ]
 readme = "README.md"
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest-recording
 h5py
 platformdirs
 pyyaml
+keyring

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ tqdm
 pytest
 pytest-recording
 h5py
+platformdirs
+pyyaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 #!/bin/env python
 
 import pytest
+import keyring
 import hdfstream
 from hdfstream.testing import pytest_recording_configure, vcr_config
 
@@ -30,3 +31,11 @@ def eagle_snap_file(server_url):
 def swift_snap_file(server_url):
     filename="Tests/SWIFT/IOExamples/ssio_ci_04_2025/EagleSingle.hdf5"
     return lambda: open_file(server_url, filename)
+
+def raise_keyring_error():
+    raise keyring.errors.KeyringError("Tests should not be using the keyring!")
+
+@pytest.fixture(autouse=True)
+def break_keyring(monkeypatch):
+    monkeypatch.setattr(keyring, "get_password", raise_keyring_error)
+    monkeypatch.setattr(keyring, "set_password", raise_keyring_error)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import pytest
 import keyring
 import hdfstream
 from hdfstream.testing import pytest_recording_configure, vcr_config, KeyringNotAvailableError
-from hdfstream.config import Config
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -42,10 +41,11 @@ def break_keyring(monkeypatch):
     monkeypatch.setattr(keyring, "set_password", raise_keyring_error)
 
 def get_test_config():
-    config = Config()
+    config = hdfstream.Config()
     config.add_alias("example", "https://example.com/hdfstream")
     return config
 
 @pytest.fixture(autouse=True)
 def use_test_config(monkeypatch):
+    monkeypatch.setattr(hdfstream, "get_config", get_test_config)
     monkeypatch.setattr(hdfstream.config, "get_config", get_test_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,3 +39,7 @@ def raise_keyring_error():
 def break_keyring(monkeypatch):
     monkeypatch.setattr(keyring, "get_password", raise_keyring_error)
     monkeypatch.setattr(keyring, "set_password", raise_keyring_error)
+
+@pytest.fixture(autouse=True)
+def use_default_config(monkeypatch):
+    monkeypatch.setattr(hdfstream.config, "get_config", hdfstream.config._default_config)

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -1,0 +1,63 @@
+#!/bin/env python
+
+import pytest
+import keyring.errors
+import hdfstream
+import hdfstream.config
+from hdfstream.testing import KeyringNotAvailableError
+
+def test_keyring_set_is_disabled():
+    with pytest.raises(KeyringNotAvailableError):
+        keyring.set_password("_system", "_username", "_password")
+
+def test_keyring_get_is_disabled():
+    with pytest.raises(KeyringNotAvailableError):
+        password = keyring.get_password("_system", "_username")
+
+def test_alias_not_found():
+    config = hdfstream.config.get_config()
+    url, user, use_keyring = config.resolve_alias("no_such_alias", None)
+    assert url == "no_such_alias"
+    assert user is None
+    assert use_keyring == False
+
+def test_alias_not_found_with_user():
+    config = hdfstream.config.get_config()
+    url, user, use_keyring = config.resolve_alias("no_such_alias", "username")
+    assert url == "no_such_alias"
+    assert user == "username"
+    assert use_keyring == False
+
+def test_alias():
+    config = hdfstream.config.get_config()
+    url, user, use_keyring = config.resolve_alias("example", None)
+    assert url == "https://example.com/hdfstream"
+    assert user is None
+    assert use_keyring == False
+
+def test_alias_with_user():
+    config = hdfstream.config.get_config()
+    url, user, use_keyring = config.resolve_alias("example", "username")
+    assert url == "https://example.com/hdfstream"
+    assert user == "username"
+    assert use_keyring == False
+
+def test_alias_yaml_round_trip(tmp_path):
+
+    # Make the test config
+    config = hdfstream.config.Config()
+    config.add_alias("test_alias", "test_url", user="test_user", use_keyring=True)
+
+    # Write the config to a file
+    filename = tmp_path / "test.yml"
+    config.write(filename)
+
+    # Read it back
+    config = hdfstream.config.Config()
+    config.read(filename)
+
+    # Check it works
+    url, user, use_keyring = config.resolve_alias("test_alias", None)
+    assert url == "test_url"
+    assert user == "test_user"
+    assert use_keyring == True

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -3,7 +3,6 @@
 import pytest
 import keyring.errors
 import hdfstream
-import hdfstream.config
 from hdfstream.testing import KeyringNotAvailableError
 
 def test_keyring_set_is_disabled():
@@ -15,28 +14,28 @@ def test_keyring_get_is_disabled():
         password = keyring.get_password("_system", "_username")
 
 def test_alias_not_found():
-    config = hdfstream.config.get_config()
+    config = hdfstream.get_config()
     url, user, use_keyring = config.resolve_alias("no_such_alias", None)
     assert url == "no_such_alias"
     assert user is None
     assert use_keyring == False
 
 def test_alias_not_found_with_user():
-    config = hdfstream.config.get_config()
+    config = hdfstream.get_config()
     url, user, use_keyring = config.resolve_alias("no_such_alias", "username")
     assert url == "no_such_alias"
     assert user == "username"
     assert use_keyring == False
 
 def test_alias():
-    config = hdfstream.config.get_config()
+    config = hdfstream.get_config()
     url, user, use_keyring = config.resolve_alias("example", None)
     assert url == "https://example.com/hdfstream"
     assert user is None
     assert use_keyring == False
 
 def test_alias_with_user():
-    config = hdfstream.config.get_config()
+    config = hdfstream.get_config()
     url, user, use_keyring = config.resolve_alias("example", "username")
     assert url == "https://example.com/hdfstream"
     assert user == "username"
@@ -45,7 +44,7 @@ def test_alias_with_user():
 def test_alias_yaml_round_trip(tmp_path):
 
     # Make the test config
-    config = hdfstream.config.Config()
+    config = hdfstream.Config()
     config.add_alias("test_alias", "test_url", user="test_user", use_keyring=True)
 
     # Write the config to a file
@@ -53,7 +52,7 @@ def test_alias_yaml_round_trip(tmp_path):
     config.write(filename)
 
     # Read it back
-    config = hdfstream.config.Config()
+    config = hdfstream.Config()
     config.read(filename)
 
     # Check it works

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -65,11 +65,11 @@ def test_set_config():
 
     # Make the test config
     config = hdfstream.Config()
-    config.add_alias("test_alias", "test_url", user="test_user", use_keyring=True)
+    config.add_alias("test_set_alias", "test_set_url", user="test_set_user", use_keyring=True)
     hdfstream.set_config(config)
 
     # Check it works
-    url, user, use_keyring = config.resolve_alias("test_alias", None)
-    assert url == "test_url"
-    assert user == "test_user"
+    url, user, use_keyring = config.resolve_alias("test_set_alias", None)
+    assert url == "test_set_url"
+    assert user == "test_set_user"
     assert use_keyring == True

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -13,6 +13,12 @@ def test_keyring_get_is_disabled():
     with pytest.raises(KeyringNotAvailableError):
         password = keyring.get_password("_system", "_username")
 
+def test_get_config_monkeypatched():
+    # Check that tests don't use the user's real configuration
+    config = hdfstream.get_config()
+    assert config is not hdfstream.config._config
+    assert "cosma" not in config._alias
+
 def test_alias_not_found():
     config = hdfstream.get_config()
     url, user, use_keyring = config.resolve_alias("no_such_alias", None)

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -60,3 +60,16 @@ def test_alias_yaml_round_trip(tmp_path):
     assert url == "test_url"
     assert user == "test_user"
     assert use_keyring == True
+
+def test_set_config():
+
+    # Make the test config
+    config = hdfstream.Config()
+    config.add_alias("test_alias", "test_url", user="test_user", use_keyring=True)
+    hdfstream.set_config(config)
+
+    # Check it works
+    url, user, use_keyring = config.resolve_alias("test_alias", None)
+    assert url == "test_url"
+    assert user == "test_user"
+    assert use_keyring == True


### PR DESCRIPTION
This is to avoid having to write a long URL in every call. The config file can also set a default username to use and a flag to indicate if we should use the keyring module to store passwords.