### PR TITLE
Fix inability to index vlen scalars with ()

### DIFF
--- a/hdfstream/decoding.py
+++ b/hdfstream/decoding.py
@@ -76,14 +76,10 @@ def decode_hook(data):
     if isinstance(data, dict) and "vlen" in data:
         # Get the shape of the array
         shape = [int(i) for i in data["shape"]]
-        if len(shape) == 0:
-            # For scalars, just return the value
-            data = data["data"][0]
-        else:
-            # Otherwise we make an object array
-            arr = np.empty(len(data["data"]), object)
-            arr[:] = data["data"]
-            data = arr.reshape(shape)
+        # Return an object array
+        arr = np.empty(len(data["data"]), object)
+        arr[:] = data["data"]
+        data = arr.reshape(shape)
     return data
 
 


### PR DESCRIPTION
Attempting to index a scalar dataset of variable length type failed because the decoder returned a bare object instead of a numpy scalar. This caused an exception when `RemoteDataset.__getitem__` tried to index it.