### PR TITLE
Avoid infinite loop on truncated response

### DIFF
--- a/hdfstream/decoding.py
+++ b/hdfstream/decoding.py
@@ -219,6 +219,8 @@ def decode_ndarray(stream, desc, progress, destination=None):
         while bytes_left > 0:
             max_to_read = min(bytes_left, chunk)
             n = stream.readinto(buf[offset:offset+max_to_read])
+            if n == 0:
+                raise RuntimeError("Array body in response is truncated!")
             bytes_left -= n
             offset += n
             progress.update(n)


### PR DESCRIPTION
This tries to catch the case where the response stream ends while we're downloading it to the array buffer. We should throw an exception rather than looping over zero size response chunks.