### PR TITLE
Only check coverage for modified lines on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
         pip install -e .
 
     - name: Generate diff for PR
+      if: github.event_name == 'pull_request'
       run: |
         git fetch origin ${{ github.base_ref }} --depth=1
         git diff origin/${{ github.base_ref }}...HEAD > changes.diff
@@ -59,6 +60,7 @@ jobs:
         coverage html
 
     - name: Check that any modified lines are tested
+      if: github.event_name == 'pull_request'
       run: |
         diff-cover coverage.xml --diff-file changes.diff --html-report diffcov.html --fail-under=100
 
@@ -70,7 +72,7 @@ jobs:
         path: htmlcov/
 
     - name: Upload coverage report for modified lines
-      if: always()
+      if: github.event_name == 'pull_request'
       uses: actions/upload-artifact@v4
       with:
         name: diff-coverage-html


### PR DESCRIPTION
When the tests run after a PR is merged, there's no separate master branch to diff against so we can't check coverage of modified lines in that case.