### PR TITLE
Increase default recursion depth and eager load size

### DIFF
--- a/hdfstream/defaults.py
+++ b/hdfstream/defaults.py
@@ -2,8 +2,8 @@
 
 # Default maximum recursion depth when loading nested groups in a single
 # request. Deeper groups are only loaded when requested.
-max_depth_default = 1
+max_depth_default = 3
 
 # Default maximum size in bytes of dataset contents to load with the parent
 # group. Larger datasets are only loaded when sliced.
-data_size_limit_default = 64*1024
+data_size_limit_default = 1024*1024


### PR DESCRIPTION
This reduces the number of requests when opening a Swift snapshot.