### PR TITLE
Increase the server version for integration tests

### DIFF
--- a/.github/workflows/lightcone_io_integration.yml
+++ b/.github/workflows/lightcone_io_integration.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         data-dir: ./downstream/lightcone_io/tests/data
         virtual-prefix: tests/data
-        image: ghcr.io/jchelly/hdfstream-api:0.0.6
+        image: ghcr.io/jchelly/hdfstream-api:0.0.7
 
     - name: Test lightcone_io with pytest
       working-directory: ./downstream/lightcone_io

--- a/.github/workflows/swiftsimio_integration.yml
+++ b/.github/workflows/swiftsimio_integration.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         data-dir: ./downstream/swiftsimio/test_data
         virtual-prefix: test_data
-        image: ghcr.io/jchelly/hdfstream-api:0.0.6
+        image: ghcr.io/jchelly/hdfstream-api:0.0.7
 
     - name: Test swiftsimio with pytest
       working-directory: ./downstream/swiftsimio


### PR DESCRIPTION
Run integration tests with a newer hdfstream docker image.